### PR TITLE
Added line break in dumpInfo

### DIFF
--- a/cocos2d/CCConfiguration.m
+++ b/cocos2d/CCConfiguration.m
@@ -394,7 +394,7 @@ static char * glExtensions;
 	printf("cocos2d: Multi-threaded rendering: %d\n", CC_RENDER_DISPATCH_ENABLED);
 	
 	if(_graphicsAPI == CCGraphicsAPIGL){
-		printf("cocos2d: OpenGL Rendering enabled.");
+		printf("cocos2d: OpenGL Rendering enabled.\n");
 		
 		CCRenderDispatch(NO, ^{
 			printf("cocos2d: GL_VENDOR:    %s\n", glGetString(GL_VENDOR) );


### PR DESCRIPTION
A line break is needed in dumpInfo to keep the two lines separate; one
has been added so order can be restored.
